### PR TITLE
[1.x] fix: log file splitting bugs, subdirectory support, and permission rename

### DIFF
--- a/.github/workflows/flarum-release-notification.yml
+++ b/.github/workflows/flarum-release-notification.yml
@@ -1,0 +1,17 @@
+name: Notify Flarum on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-flarum:
+    uses: FriendsOfFlarum/extension-releases/.github/workflows/REUSABLE_flarum-release-notification.yml@2.x
+    with:
+      changelog: ${{ github.event.release.body || '' }}
+      tag_name: ${{ github.event.release.tag_name }}
+      release_url: ${{ github.event.release.html_url }}
+      author: ${{ github.event.release.author.login || github.actor || '' }}
+      ref: ${{ github.ref }}
+    secrets:
+      flarum_api_token: ${{ secrets.FLARUM_EXTENSION_UPDATES_API_TOKEN }}

--- a/js/src/admin/components/LogFileList.tsx
+++ b/js/src/admin/components/LogFileList.tsx
@@ -47,7 +47,7 @@ export default class LogFileList extends Component {
   }
 
   parseResults(results) {
-    this.files.push(...results);
+    this.files = results;
 
     this.loading = false;
 

--- a/js/src/admin/components/LogFileListItem.tsx
+++ b/js/src/admin/components/LogFileListItem.tsx
@@ -25,7 +25,7 @@ export default class LogFileListItem extends Component {
           <div className="LogFile-info">
             <div className="fileName">
               {icon('far fa-file-alt')}
-              <code>{file.fileName()}</code>
+              <code>{file.relativePath()}</code>
             </div>
             <div className="fileDate">
               {app.translator.trans('ianm-log-viewer.admin.viewer.last_updated', {
@@ -40,17 +40,17 @@ export default class LogFileListItem extends Component {
           </div>
           <div className="LogFile-actions">
             <Tooltip text={app.translator.trans('ianm-log-viewer.admin.viewer.view_log')}>
-              <Button className="Button Button--icon" icon="fas fa-eye" onclick={() => this.setFile(file.fileName())} />
+              <Button className="Button Button--icon" icon="fas fa-eye" onclick={() => this.setFile(file.relativePath())} />
             </Tooltip>
             <Tooltip text={app.translator.trans('ianm-log-viewer.admin.viewer.download_log')}>
-              <Button className="Button Button--icon" icon="fas fa-download" onclick={() => this.downloadFile(file.fileName())} />
+              <Button className="Button Button--icon" icon="fas fa-download" onclick={() => this.downloadFile(file.relativePath())} />
             </Tooltip>
             <Tooltip text={app.translator.trans('ianm-log-viewer.admin.viewer.delete_log')}>
               <Button
                 className="Button Button--icon Button--danger"
                 icon="fas fa-trash"
                 loading={this.loading}
-                onclick={() => this.deleteFile(file.fileName())}
+                onclick={() => this.deleteFile(file.relativePath())}
               />
             </Tooltip>
           </div>

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -11,7 +11,7 @@ app.initializers.add('ianm-log-viewer', () => {
       {
         icon: 'far fa-file-alt',
         label: app.translator.trans('ianm-log-viewer.admin.permissions.access_logfile_api'),
-        permission: 'readLogfiles',
+        permission: 'manageLogfiles',
       },
       'view'
     )

--- a/js/src/admin/models/LogFile.ts
+++ b/js/src/admin/models/LogFile.ts
@@ -5,6 +5,10 @@ export default class LogFile extends Model {
     return Model.attribute<string>('fileName').call(this);
   }
 
+  relativePath() {
+    return Model.attribute<string>('relativePath').call(this);
+  }
+
   fullPath() {
     return Model.attribute<string>('fullPath').call(this);
   }

--- a/js/src/admin/state/LogFileState.ts
+++ b/js/src/admin/state/LogFileState.ts
@@ -1,5 +1,9 @@
 import app from 'flarum/admin/app';
 
+function encodeId(relativePath: string): string {
+  return btoa(relativePath).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 export default class LogFileState {
   file: any;
   onRefresh: (() => void) | null;
@@ -13,11 +17,12 @@ export default class LogFileState {
     this.onRefresh = callback;
   }
 
-  loadLogFile(filename: string) {
+  loadLogFile(relativePath: string) {
+    const encodedId = encodeId(relativePath);
     app
       .request({
         method: 'GET',
-        url: app.forum.attribute('apiUrl') + '/logs/' + filename,
+        url: app.forum.attribute('apiUrl') + '/logs/' + encodedId + '?file=' + encodedId,
       })
       .then((result) => {
         this.file = result;
@@ -29,24 +34,27 @@ export default class LogFileState {
     return this.file;
   }
 
-  downloadFile(filename: string) {
-    const url = app.forum.attribute('apiUrl') + '/logs/download/' + filename + '?file=' + filename;
+  downloadFile(relativePath: string) {
+    const encodedId = encodeId(relativePath);
+    const url = app.forum.attribute('apiUrl') + '/logs/download/' + encodedId + '?file=' + encodedId;
     window.open(url, '_blank');
   }
 
-  deleteFile(filename: string) {
+  deleteFile(relativePath: string) {
     if (!confirm(app.translator.trans('ianm-log-viewer.admin.viewer.confirm_delete'))) {
       return Promise.resolve();
     }
 
+    const encodedId = encodeId(relativePath);
+
     return app
       .request({
         method: 'DELETE',
-        url: app.forum.attribute('apiUrl') + '/logs/' + filename + '?file=' + filename,
+        url: app.forum.attribute('apiUrl') + '/logs/' + encodedId + '?file=' + encodedId,
       })
       .then(() => {
         // Clear the currently selected file if it was deleted
-        if (this.file && this.file.data.attributes.fileName === filename) {
+        if (this.file && this.file.data.attributes.relativePath === relativePath) {
           this.file = null;
         }
 

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1,7 +1,7 @@
 ianm-log-viewer:
   admin:
     permissions:
-      access_logfile_api: Access logfile data via the API
+      access_logfile_api: View and manage logfiles
     settings:
       max-file-size: Maximum Log File Size (MB)
       max-file-size-help: If a log file exceeds this size, it will be split into multiple parts. Set to 0 to disable splitting. Default is 1MB. Maximum allowable size is 150MB.

--- a/src/Api/Controller/DeleteLogFileController.php
+++ b/src/Api/Controller/DeleteLogFileController.php
@@ -37,34 +37,40 @@ class DeleteLogFileController implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        RequestUtil::getActor($request)->assertCan('readLogfiles');
+        RequestUtil::getActor($request)->assertCan('manageLogfiles');
 
-        $fileName = Arr::get($request->getQueryParams(), 'file');
+        $encodedId = Arr::get($request->getQueryParams(), 'file');
 
-        if (! $fileName) {
+        if (! $encodedId) {
             throw new RouteNotFoundException();
         }
 
-        // Sanitize the filename to prevent directory traversal
-        $fileName = basename($fileName);
+        $relativePath = base64_decode(strtr($encodedId, '-_', '+/'));
+
+        if ($relativePath === '') {
+            throw new RouteNotFoundException();
+        }
 
         $logDir = $this->getLogDirectory($this->paths);
-        $filePath = $logDir.DIRECTORY_SEPARATOR.$fileName;
+        $realLogDir = realpath($logDir);
 
-        if (! file_exists($filePath) || ! is_file($filePath)) {
+        if (! $realLogDir) {
             throw new RouteNotFoundException();
         }
 
-        // Security check: ensure the file is within the log directory
-        $realLogDir = realpath($logDir);
-        $realFilePath = realpath($filePath);
+        $realFilePath = realpath($realLogDir.DIRECTORY_SEPARATOR.$relativePath);
 
-        if (! $realFilePath || strpos($realFilePath, $realLogDir) !== 0) {
+        // Security check: ensure the file is within the log directory
+        if (! $realFilePath || strpos($realFilePath, $realLogDir.DIRECTORY_SEPARATOR) !== 0) {
+            throw new RouteNotFoundException();
+        }
+
+        if (! is_file($realFilePath)) {
             throw new RouteNotFoundException();
         }
 
         // Delete the file
-        unlink($filePath);
+        unlink($realFilePath);
 
         return new EmptyResponse(204);
     }

--- a/src/Api/Controller/DownloadLogFileController.php
+++ b/src/Api/Controller/DownloadLogFileController.php
@@ -38,38 +38,44 @@ class DownloadLogFileController implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        RequestUtil::getActor($request)->assertCan('readLogfiles');
+        RequestUtil::getActor($request)->assertCan('manageLogfiles');
 
-        $fileName = Arr::get($request->getQueryParams(), 'file');
+        $encodedId = Arr::get($request->getQueryParams(), 'file');
 
-        if (! $fileName) {
+        if (! $encodedId) {
             throw new RouteNotFoundException();
         }
 
-        // Sanitize the filename to prevent directory traversal
-        $fileName = basename($fileName);
+        $relativePath = base64_decode(strtr($encodedId, '-_', '+/'));
+
+        if ($relativePath === '') {
+            throw new RouteNotFoundException();
+        }
 
         $logDir = $this->getLogDirectory($this->paths);
-        $filePath = $logDir.DIRECTORY_SEPARATOR.$fileName;
+        $realLogDir = realpath($logDir);
 
-        if (! file_exists($filePath) || ! is_file($filePath)) {
+        if (! $realLogDir) {
             throw new RouteNotFoundException();
         }
+
+        $realFilePath = realpath($realLogDir.DIRECTORY_SEPARATOR.$relativePath);
 
         // Security check: ensure the file is within the log directory
-        $realLogDir = realpath($logDir);
-        $realFilePath = realpath($filePath);
-
-        if (! $realFilePath || strpos($realFilePath, $realLogDir) !== 0) {
+        if (! $realFilePath || strpos($realFilePath, $realLogDir.DIRECTORY_SEPARATOR) !== 0) {
             throw new RouteNotFoundException();
         }
 
-        $stream = new Stream($filePath, 'r');
-        $fileSize = filesize($filePath);
+        if (! is_file($realFilePath)) {
+            throw new RouteNotFoundException();
+        }
+
+        $stream = new Stream($realFilePath, 'r');
+        $fileSize = filesize($realFilePath);
 
         $headers = [
             'Content-Type' => 'application/octet-stream',
-            'Content-Disposition' => 'attachment; filename="'.basename($fileName).'"',
+            'Content-Disposition' => 'attachment; filename="'.basename($realFilePath).'"',
         ];
 
         if ($fileSize !== false) {

--- a/src/Api/Controller/ListLogfilesController.php
+++ b/src/Api/Controller/ListLogfilesController.php
@@ -31,32 +31,26 @@ class ListLogfilesController extends AbstractListController
      */
     protected $paths;
 
-    /**
-     * @var Finder
-     */
-    protected $finder;
-
     public $serializer = FileListSerializer::class;
 
-    public function __construct(Paths $paths, Finder $finder)
+    public function __construct(Paths $paths)
     {
         $this->paths = $paths;
-        $this->finder = $finder;
     }
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        RequestUtil::getActor($request)->assertCan('readLogfiles');
+        RequestUtil::getActor($request)->assertCan('manageLogfiles');
 
         $logDir = $this->getLogDirectory($this->paths);
 
-        $files = new Collection();
-        $this->finder->files()->in($logDir);
-        foreach ($this->finder as $file) {
-            /** @var \Symfony\Component\Finder\SplFileInfo $file */
-            $logfile = LogFile::build($file);
+        $finder = new Finder();
+        $finder->files()->in($logDir);
 
-            $files->add($logfile);
+        $files = new Collection();
+        foreach ($finder as $file) {
+            /** @var \Symfony\Component\Finder\SplFileInfo $file */
+            $files->add(LogFile::build($file));
         }
 
         return $files->sortBy(function ($object) {

--- a/src/Api/Controller/ShowLogFileController.php
+++ b/src/Api/Controller/ShowLogFileController.php
@@ -40,15 +40,26 @@ class ShowLogFileController extends AbstractShowController
 
     protected function data(ServerRequestInterface $request, Document $document)
     {
-        $fileName = Arr::get($request->getQueryParams(), 'file');
-        RequestUtil::getActor($request)->assertCan('readLogfiles');
+        RequestUtil::getActor($request)->assertCan('manageLogfiles');
 
-        $logDir = $this->getLogDirectory($this->paths);
+        $encodedId = Arr::get($request->getQueryParams(), 'file');
 
-        if (! file_exists($logDir.DIRECTORY_SEPARATOR.$fileName)) {
+        if (! $encodedId) {
             throw new RouteNotFoundException();
         }
 
-        return LogFile::find($fileName, $logDir, true);
+        $relativePath = base64_decode(strtr($encodedId, '-_', '+/'));
+
+        if ($relativePath === '') {
+            throw new RouteNotFoundException();
+        }
+
+        $logDir = $this->getLogDirectory($this->paths);
+
+        try {
+            return LogFile::find($relativePath, $logDir, true);
+        } catch (\RuntimeException $e) {
+            throw new RouteNotFoundException();
+        }
     }
 }

--- a/src/Api/Serializer/FileListSerializer.php
+++ b/src/Api/Serializer/FileListSerializer.php
@@ -18,12 +18,29 @@ class FileListSerializer extends AbstractSerializer
     protected $type = 'logs';
 
     /**
+     * Encode a relative path as a URL-safe base64 string for use as the resource ID.
+     */
+    public static function encodeId(string $relativePath): string
+    {
+        return rtrim(strtr(base64_encode($relativePath), '+/', '-_'), '=');
+    }
+
+    /**
+     * @param \IanM\LogViewer\Model\LogFile $model
+     */
+    public function getId($model)
+    {
+        return self::encodeId($model->relativePath);
+    }
+
+    /**
      * @param \IanM\LogViewer\Model\LogFile $model
      */
     protected function getDefaultAttributes($model)
     {
         $attributes = [
             'fileName' => $model->fileName,
+            'relativePath' => $model->relativePath,
             'fullPath' => $model->fullPath,
             'size' => $model->size,
             'modified' => $this->formatDate($model->modified),

--- a/src/Console/CleanupLogfilesCommand.php
+++ b/src/Console/CleanupLogfilesCommand.php
@@ -68,7 +68,7 @@ class CleanupLogfilesCommand extends Command
         }
 
         if ((int) $purgeDays < 0) {
-            return -1;  // Indicate disabled cleanup for negative values
+            return 0;  // Treat negative values as disabled (same as zero)
         }
 
         return (int) $purgeDays;

--- a/src/Console/SplitLargeLogfilesCommand.php
+++ b/src/Console/SplitLargeLogfilesCommand.php
@@ -113,10 +113,11 @@ class SplitLargeLogfilesCommand extends Command
 
         // If the original filename would collide with chunk 1 (e.g. re-splitting largeTest-part1.log),
         // rename the original to a temporary name first so reads and writes don't interfere.
+        // Use dirname($originalFilePath) to get the absolute directory, not $file->getPath() which is relative.
         $readPath = $originalFilePath;
         $tempPath = null;
         if ($hadPartSuffix) {
-            $firstChunkPath = $file->getPath().DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
+            $firstChunkPath = dirname($originalFilePath).DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
             if ($firstChunkPath === $originalFilePath) {
                 $tempPath = $originalFilePath.'.splitting';
                 if (! rename($originalFilePath, $tempPath)) {
@@ -149,7 +150,7 @@ class SplitLargeLogfilesCommand extends Command
             }
 
             $filename = $baseNameWithoutExtension.'-part'.$partNumber.'.'.$extension;
-            $filePath = $file->getPath().DIRECTORY_SEPARATOR.$filename;
+            $filePath = dirname($originalFilePath).DIRECTORY_SEPARATOR.$filename;
 
             // Write the chunk to a new part file
             if (file_put_contents($filePath, $chunk) === false) {
@@ -172,7 +173,7 @@ class SplitLargeLogfilesCommand extends Command
         } else {
             // Only one chunk — no real split happened; remove the single part file
             // and restore the original name if we had renamed it
-            $singlePartPath = $file->getPath().DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
+            $singlePartPath = dirname($originalFilePath).DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
             if ($tempPath) {
                 // Restore original name; singlePartPath may or may not exist
                 if (file_exists($singlePartPath) && $singlePartPath !== $originalFilePath) {

--- a/src/Console/SplitLargeLogfilesCommand.php
+++ b/src/Console/SplitLargeLogfilesCommand.php
@@ -84,7 +84,7 @@ class SplitLargeLogfilesCommand extends Command
         $finder = new Finder();
         $finder->files()
             ->in($this->getLogDirectory($this->paths))
-            ->size('>'.$maxFileSize);
+            ->size('> '.$maxFileSize);
 
         return $finder;
     }
@@ -104,25 +104,52 @@ class SplitLargeLogfilesCommand extends Command
         $baseNameWithoutExtension = pathinfo($file->getBasename(), PATHINFO_FILENAME);
         $extension = pathinfo($file->getBasename(), PATHINFO_EXTENSION);
 
-        // Determine the starting part number
-        $existingParts = preg_match('/-part(\\d+)$/', $baseNameWithoutExtension, $matches);
-        $partNumber = $existingParts ? (int) $matches[1] + 1 : 1;
+        // Strip any existing -partN suffix to avoid compounding names on re-split
+        $hadPartSuffix = false;
+        if (preg_match('/^(.*)-part(\d+)$/', $baseNameWithoutExtension, $matches)) {
+            $baseNameWithoutExtension = $matches[1];
+            $hadPartSuffix = true;
+        }
 
-        // Open the original file for reading
-        $handle = fopen($originalFilePath, 'rb');
+        // If the original filename would collide with chunk 1 (e.g. re-splitting largeTest-part1.log),
+        // rename the original to a temporary name first so reads and writes don't interfere.
+        $readPath = $originalFilePath;
+        $tempPath = null;
+        if ($hadPartSuffix) {
+            $firstChunkPath = $file->getPath().DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
+            if ($firstChunkPath === $originalFilePath) {
+                $tempPath = $originalFilePath.'.splitting';
+                if (! rename($originalFilePath, $tempPath)) {
+                    $this->error('Error renaming file for splitting: '.$originalFilePath);
+
+                    return;
+                }
+                $readPath = $tempPath;
+            }
+        }
+
+        // Open the file for reading
+        $handle = fopen($readPath, 'rb');
         if (! $handle) {
-            $this->error('Error opening file: '.$originalFilePath);
+            $this->error('Error opening file: '.$readPath);
+            if ($tempPath) {
+                rename($tempPath, $originalFilePath);
+            }
 
             return;
         }
 
-        $partFiles = [];
+        $partNumber = 1;
+        $partsWritten = 0;
         while (! feof($handle)) {
+            $chunk = fread($handle, $maxFileSize);
+
+            if ($chunk === false || strlen($chunk) === 0) {
+                break;
+            }
+
             $filename = $baseNameWithoutExtension.'-part'.$partNumber.'.'.$extension;
             $filePath = $file->getPath().DIRECTORY_SEPARATOR.$filename;
-
-            // Read a chunk of the file
-            $chunk = fread($handle, $maxFileSize);
 
             // Write the chunk to a new part file
             if (file_put_contents($filePath, $chunk) === false) {
@@ -132,21 +159,29 @@ class SplitLargeLogfilesCommand extends Command
                 return;
             }
 
-            $partFiles[] = $filePath;
+            $partsWritten++;
             $partNumber++;
         }
 
-        // Close the original file handle
+        // Close the file handle
         fclose($handle);
 
-        // Rename the original file to become the last part (if there are multiple parts)
-        if (count($partFiles) > 1) {
-            $lastPartFileName = $baseNameWithoutExtension.'-part'.($partNumber - 1).'.'.$extension;
-            $lastPartFilePath = $file->getPath().DIRECTORY_SEPARATOR.$lastPartFileName;
-            rename($originalFilePath, $lastPartFilePath);
+        if ($partsWritten > 1) {
+            // All chunks were written to numbered part files; delete the source
+            unlink($readPath);
         } else {
-            // If there's only one part, delete the split file and keep the original
-            unlink($partFiles[0]);
+            // Only one chunk — no real split happened; remove the single part file
+            // and restore the original name if we had renamed it
+            $singlePartPath = $file->getPath().DIRECTORY_SEPARATOR.$baseNameWithoutExtension.'-part1.'.$extension;
+            if ($tempPath) {
+                // Restore original name; singlePartPath may or may not exist
+                if (file_exists($singlePartPath) && $singlePartPath !== $originalFilePath) {
+                    @unlink($singlePartPath);
+                }
+                rename($tempPath, $originalFilePath);
+            } else {
+                @unlink($singlePartPath);
+            }
         }
     }
 }

--- a/src/Model/LogFile.php
+++ b/src/Model/LogFile.php
@@ -12,15 +12,13 @@
 namespace IanM\LogViewer\Model;
 
 use Carbon\Carbon;
-use Illuminate\Support\Str;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 class LogFile
 {
-    public $id;
-
     public $fileName;
+
+    public $relativePath;
 
     public $fullPath;
 
@@ -34,8 +32,8 @@ class LogFile
     {
         $logFile = new self();
 
-        $logFile->id = Str::slug($file->getFilename());
         $logFile->fileName = $file->getFilename();
+        $logFile->relativePath = $file->getRelativePathname();
         $logFile->fullPath = $file->getRealPath();
         $logFile->size = $file->getSize();
         $logFile->modified = Carbon::createFromTimestamp($file->getMTime());
@@ -50,22 +48,28 @@ class LogFile
         return $logFile;
     }
 
-    public static function find(string $fileName, string $path, bool $withContent = false): self
+    public static function find(string $relativePath, string $logDir, bool $withContent = false): self
     {
-        /** @var Finder $finder */
-        $finder = resolve(Finder::class);
-        $finder->files()
-            ->in($path)
-            ->name($fileName);
+        $realLogDir = realpath($logDir);
 
-        if (! $finder->hasResults()) {
+        if (! $realLogDir) {
+            throw new \RuntimeException('Log directory not found.');
+        }
+
+        $fullPath = realpath($realLogDir.DIRECTORY_SEPARATOR.$relativePath);
+
+        // Security check: ensure the file is within the log directory
+        if (! $fullPath || strpos($fullPath, $realLogDir.DIRECTORY_SEPARATOR) !== 0) {
             throw new \RuntimeException('Log file not found.');
         }
 
-        foreach ($finder as $file) {
-            return self::build($file, $withContent);
+        if (! is_file($fullPath)) {
+            throw new \RuntimeException('Log file not found.');
         }
 
-        throw new \RuntimeException('Log file not found.');
+        $relDir = ltrim(str_replace($realLogDir, '', dirname($fullPath)), DIRECTORY_SEPARATOR);
+        $file = new SplFileInfo($fullPath, $relDir, $relativePath);
+
+        return self::build($file, $withContent);
     }
 }

--- a/tests/integration/api/ListLogFilesTest.php
+++ b/tests/integration/api/ListLogFilesTest.php
@@ -35,14 +35,13 @@ class ListLogFileTest extends TestCase
                 ['group_id' => 4, 'user_id' => 3],
             ],
             'group_permission' => [
-                ['group_id' => 4, 'permission' => 'readLogfiles'],
+                ['group_id' => 4, 'permission' => 'manageLogfiles'],
             ]
         ]);
 
         // Delete any existing log files before starting
         $paths = $this->app()->getContainer()->make('flarum.paths');
         $logDir = $paths->storage.'/logs';
-        // check the folder exists, if not, create it
         if (! is_dir($logDir)) {
             mkdir($logDir, 0777, true);
         }
@@ -51,6 +50,14 @@ class ListLogFileTest extends TestCase
         foreach ($finder as $file) {
             unlink($file->getRealPath());
         }
+    }
+
+    /**
+     * Encode a relative path as URL-safe base64 (matches FileListSerializer::encodeId).
+     */
+    protected function encodeId(string $relativePath): string
+    {
+        return rtrim(strtr(base64_encode($relativePath), '+/', '-_'), '=');
     }
 
     /**
@@ -118,10 +125,10 @@ class ListLogFileTest extends TestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
         $data = Arr::get($json, 'data');
-        $logFileName = Arr::get($data[0], 'attributes.fileName');
+        $encodedId = Arr::get($data[0], 'id');
 
         $response = $this->send(
-            $this->request('GET', "/api/logs/$logFileName", [
+            $this->request('GET', "/api/logs/$encodedId", [
                 'authenticatedAs' => 3,
             ])
         );
@@ -152,10 +159,10 @@ class ListLogFileTest extends TestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
         $data = Arr::get($json, 'data');
-        $logFileName = Arr::get($data[0], 'id');
+        $encodedId = Arr::get($data[0], 'id');
 
         $response = $this->send(
-            $this->request('GET', "/api/logs/$logFileName", [
+            $this->request('GET', "/api/logs/$encodedId", [
                 'authenticatedAs' => 2,
             ])
         );
@@ -168,8 +175,10 @@ class ListLogFileTest extends TestCase
      */
     public function unauthorized_user_cannot_get_logfile_not_existing()
     {
+        $encodedId = $this->encodeId('idontexist.log');
+
         $response = $this->send(
-            $this->request('GET', '/api/logs/idontexist.log', [
+            $this->request('GET', "/api/logs/$encodedId", [
                 'authenticatedAs' => 2,
             ])
         );
@@ -182,13 +191,10 @@ class ListLogFileTest extends TestCase
      */
     public function authorized_user_can_get_logfile_with_malformed_utf8()
     {
-        // Create a log file with malformed UTF-8 characters
         $paths = $this->app()->getContainer()->make('flarum.paths');
         $logDir = $paths->storage.'/logs';
         $testLogFile = $logDir.'/test-malformed-utf8.log';
 
-        // Write content with invalid UTF-8 byte sequences
-        // \xFF is invalid in UTF-8, as are other sequences like \x80-\xBF without proper leading bytes
         $malformedContent = "Valid UTF-8 line\n";
         $malformedContent .= "Line with invalid UTF-8: \xFF\xFE\x80\x81\n";
         $malformedContent .= "Another valid line\n";
@@ -196,9 +202,10 @@ class ListLogFileTest extends TestCase
 
         file_put_contents($testLogFile, $malformedContent);
 
-        // List log files to get the file name
+        $encodedId = $this->encodeId('test-malformed-utf8.log');
+
         $response = $this->send(
-            $this->request('GET', '/api/logs', [
+            $this->request('GET', "/api/logs/$encodedId", [
                 'authenticatedAs' => 3,
             ])
         );
@@ -208,46 +215,14 @@ class ListLogFileTest extends TestCase
         $json = json_decode($response->getBody()->getContents(), true);
         $data = Arr::get($json, 'data');
 
-        // Find our test log file
-        $testLog = null;
-        foreach ($data as $log) {
-            if (Arr::get($log, 'attributes.fileName') === 'test-malformed-utf8.log') {
-                $testLog = $log;
-                break;
-            }
-        }
-
-        $this->assertNotNull($testLog, 'Test log file should be found in the list');
-
-        // Now fetch the log file content - this should NOT throw a JSON encoding exception
-        $logFileName = Arr::get($testLog, 'attributes.fileName');
-        $response = $this->send(
-            $this->request('GET', "/api/logs/$logFileName", [
-                'authenticatedAs' => 3,
-            ])
-        );
-
-        // Should successfully return 200, not 500 with JSON encoding error
-        $this->assertEquals(200, $response->getStatusCode());
-
-        $json = json_decode($response->getBody()->getContents(), true);
-        $data = Arr::get($json, 'data');
-
-        // Verify we got the content back
         $this->assertIsArray($json['data']);
         $this->assertEquals('logs', Arr::get($data, 'type'));
 
         $content = $data['attributes']['content'];
-
-        // The content should contain the valid parts
         $this->assertStringContainsString('Valid UTF-8 line', $content);
         $this->assertStringContainsString('Another valid line', $content);
-
-        // The malformed UTF-8 sequences should be replaced with replacement characters
-        // and the response should be valid JSON (which we've already verified by decoding it)
         $this->assertNotEmpty($content);
 
-        // Clean up
         unlink($testLogFile);
     }
 
@@ -268,13 +243,13 @@ class ListLogFileTest extends TestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
         $data = Arr::get($json, 'data');
+        $encodedId = Arr::get($data[0], 'id');
         $logFileName = Arr::get($data[0], 'attributes.fileName');
 
-        // Test download endpoint
         $response = $this->send(
-            $this->request('GET', '/api/logs/download/'.$logFileName, [
+            $this->request('GET', '/api/logs/download/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => $logFileName])
+            ])
         );
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -282,7 +257,6 @@ class ListLogFileTest extends TestCase
         $this->assertStringContainsString('attachment', $response->getHeaderLine('Content-Disposition'));
         $this->assertStringContainsString($logFileName, $response->getHeaderLine('Content-Disposition'));
 
-        // Verify content is downloadable
         $body = $response->getBody()->getContents();
         $this->assertStringContainsString('Download test content', $body);
     }
@@ -302,13 +276,12 @@ class ListLogFileTest extends TestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
         $data = Arr::get($json, 'data');
-        $logFileName = Arr::get($data[0], 'attributes.fileName');
+        $encodedId = Arr::get($data[0], 'id');
 
-        // Try to download as unauthorized user
         $response = $this->send(
-            $this->request('GET', '/api/logs/download/'.$logFileName, [
+            $this->request('GET', '/api/logs/download/'.$encodedId, [
                 'authenticatedAs' => 2,
-            ])->withQueryParams(['file' => $logFileName])
+            ])
         );
 
         $this->assertEquals(403, $response->getStatusCode());
@@ -319,10 +292,12 @@ class ListLogFileTest extends TestCase
      */
     public function download_nonexistent_file_returns_404()
     {
+        $encodedId = $this->encodeId('nonexistent.log');
+
         $response = $this->send(
-            $this->request('GET', '/api/logs/download/nonexistent.log', [
+            $this->request('GET', '/api/logs/download/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => 'nonexistent.log'])
+            ])
         );
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -333,7 +308,6 @@ class ListLogFileTest extends TestCase
      */
     public function authorized_user_can_delete_logfile()
     {
-        // Create a test log file
         $paths = $this->app()->getContainer()->make('flarum.paths');
         $logDir = $paths->storage.'/logs';
         $testLogFile = $logDir.'/test-delete.log';
@@ -341,11 +315,12 @@ class ListLogFileTest extends TestCase
 
         $this->assertTrue(file_exists($testLogFile));
 
-        // Delete the file
+        $encodedId = $this->encodeId('test-delete.log');
+
         $response = $this->send(
-            $this->request('DELETE', '/api/logs/test-delete.log', [
+            $this->request('DELETE', '/api/logs/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => 'test-delete.log'])
+            ])
         );
 
         $this->assertEquals(204, $response->getStatusCode());
@@ -357,23 +332,22 @@ class ListLogFileTest extends TestCase
      */
     public function unauthorized_user_cannot_delete_logfile()
     {
-        // Create a test log file
         $paths = $this->app()->getContainer()->make('flarum.paths');
         $logDir = $paths->storage.'/logs';
         $testLogFile = $logDir.'/test-delete-unauthorized.log';
         file_put_contents($testLogFile, 'This file should not be deleted');
 
-        // Try to delete as unauthorized user
+        $encodedId = $this->encodeId('test-delete-unauthorized.log');
+
         $response = $this->send(
-            $this->request('DELETE', '/api/logs/test-delete-unauthorized.log', [
+            $this->request('DELETE', '/api/logs/'.$encodedId, [
                 'authenticatedAs' => 2,
-            ])->withQueryParams(['file' => 'test-delete-unauthorized.log'])
+            ])
         );
 
         $this->assertEquals(403, $response->getStatusCode());
         $this->assertTrue(file_exists($testLogFile));
 
-        // Clean up
         unlink($testLogFile);
     }
 
@@ -382,10 +356,12 @@ class ListLogFileTest extends TestCase
      */
     public function delete_nonexistent_file_returns_404()
     {
+        $encodedId = $this->encodeId('nonexistent.log');
+
         $response = $this->send(
-            $this->request('DELETE', '/api/logs/nonexistent.log', [
+            $this->request('DELETE', '/api/logs/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => 'nonexistent.log'])
+            ])
         );
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -396,11 +372,12 @@ class ListLogFileTest extends TestCase
      */
     public function cannot_delete_file_outside_log_directory()
     {
-        // Try path traversal attack
+        $encodedId = $this->encodeId('../../../etc/passwd');
+
         $response = $this->send(
-            $this->request('DELETE', '/api/logs/../../../etc/passwd', [
+            $this->request('DELETE', '/api/logs/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => '../../../etc/passwd'])
+            ])
         );
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -411,13 +388,143 @@ class ListLogFileTest extends TestCase
      */
     public function cannot_download_file_outside_log_directory()
     {
-        // Try path traversal attack
+        $encodedId = $this->encodeId('../../../etc/passwd');
+
         $response = $this->send(
-            $this->request('GET', '/api/logs/download/../../../etc/passwd', [
+            $this->request('GET', '/api/logs/download/'.$encodedId, [
                 'authenticatedAs' => 3,
-            ])->withQueryParams(['file' => '../../../etc/passwd'])
+            ])
         );
 
         $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function authorized_user_can_list_subdirectory_logfiles()
+    {
+        $paths = $this->app()->getContainer()->make('flarum.paths');
+        $logDir = $paths->storage.'/logs';
+        $subDir = $logDir.'/subdir';
+
+        if (! is_dir($subDir)) {
+            mkdir($subDir, 0777, true);
+        }
+
+        file_put_contents($subDir.'/sub-test.log', 'Subdirectory log content');
+
+        $response = $this->send(
+            $this->request('GET', '/api/logs', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $data = Arr::get($json, 'data');
+        $this->assertIsArray($data);
+
+        $relativePaths = array_column(array_column($data, 'attributes'), 'relativePath');
+        $this->assertContains('subdir/sub-test.log', $relativePaths);
+
+        unlink($subDir.'/sub-test.log');
+        rmdir($subDir);
+    }
+
+    /**
+     * @test
+     */
+    public function authorized_user_can_view_subdirectory_logfile()
+    {
+        $paths = $this->app()->getContainer()->make('flarum.paths');
+        $logDir = $paths->storage.'/logs';
+        $subDir = $logDir.'/subdir';
+
+        if (! is_dir($subDir)) {
+            mkdir($subDir, 0777, true);
+        }
+
+        file_put_contents($subDir.'/sub-view.log', 'Subdirectory view content');
+
+        $encodedId = $this->encodeId('subdir/sub-view.log');
+
+        $response = $this->send(
+            $this->request('GET', "/api/logs/$encodedId", [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $data = Arr::get($json, 'data');
+        $this->assertStringContainsString('Subdirectory view content', $data['attributes']['content']);
+
+        unlink($subDir.'/sub-view.log');
+        rmdir($subDir);
+    }
+
+    /**
+     * @test
+     */
+    public function authorized_user_can_download_subdirectory_logfile()
+    {
+        $paths = $this->app()->getContainer()->make('flarum.paths');
+        $logDir = $paths->storage.'/logs';
+        $subDir = $logDir.'/subdir';
+
+        if (! is_dir($subDir)) {
+            mkdir($subDir, 0777, true);
+        }
+
+        file_put_contents($subDir.'/sub-download.log', 'Subdirectory download content');
+
+        $encodedId = $this->encodeId('subdir/sub-download.log');
+
+        $response = $this->send(
+            $this->request('GET', "/api/logs/download/$encodedId", [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('Subdirectory download content', $response->getBody()->getContents());
+
+        unlink($subDir.'/sub-download.log');
+        rmdir($subDir);
+    }
+
+    /**
+     * @test
+     */
+    public function authorized_user_can_delete_subdirectory_logfile()
+    {
+        $paths = $this->app()->getContainer()->make('flarum.paths');
+        $logDir = $paths->storage.'/logs';
+        $subDir = $logDir.'/subdir';
+
+        if (! is_dir($subDir)) {
+            mkdir($subDir, 0777, true);
+        }
+
+        $subFile = $subDir.'/sub-delete.log';
+        file_put_contents($subFile, 'Will be deleted');
+
+        $encodedId = $this->encodeId('subdir/sub-delete.log');
+
+        $response = $this->send(
+            $this->request('DELETE', "/api/logs/$encodedId", [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertFalse(file_exists($subFile));
+
+        if (is_dir($subDir)) {
+            rmdir($subDir);
+        }
     }
 }

--- a/tests/integration/console/SplitLargeLogfilesCommandTest.php
+++ b/tests/integration/console/SplitLargeLogfilesCommandTest.php
@@ -51,6 +51,8 @@ class SplitLargeLogfilesCommandTest extends ConsoleTestCase
         $paths = $this->app()->getContainer()->make('flarum.paths');
         $logDir = $paths->storage.'/logs';
 
+        // Original file should be deleted after splitting
+        $this->assertFileDoesNotExist($logDir.'/'.$this->largeLogFileName);
         $this->assertFileExists($logDir.'/'.'largeTest-part1.log');
         $this->assertFileExists($logDir.'/'.'largeTest-part2.log');
         $this->assertFileExists($logDir.'/'.'largeTest-part3.log');
@@ -74,9 +76,10 @@ class SplitLargeLogfilesCommandTest extends ConsoleTestCase
         $logDir = $paths->storage.'/logs';
 
         $filesToDelete = [
+            $this->largeLogFileName,
             'largeTest-part1.log',
             'largeTest-part2.log',
-            'largeTest-part3.log'
+            'largeTest-part3.log',
         ];
 
         foreach ($filesToDelete as $filename) {
@@ -139,6 +142,32 @@ class SplitLargeLogfilesCommandTest extends ConsoleTestCase
         $this->assertFileExists($logDir.'/'.'largeTest-part1.log');
         $this->assertFileExists($logDir.'/'.'largeTest-part2.log');
         $this->assertFileExists($logDir.'/'.'largeTest-part3.log');
+
+        $this->cleanupLogFiles();
+    }
+
+    /**
+     * @test
+     */
+    public function test_resplitting_an_already_split_file_does_not_compound_part_names()
+    {
+        $paths = $this->app()->getContainer()->make('flarum.paths');
+        $logDir = $paths->storage.'/logs';
+
+        // Simulate an already-split file that is still too large
+        $largeContent = Str::random(($this->maxFileSize * 1024 * 1024) * 2.5);
+        file_put_contents($logDir.'/largeTest-part1.log', $largeContent);
+
+        $input = ['command' => 'logfiles:split-large'];
+        $this->runCommand($input);
+
+        // Resulting files must be largeTest-part1.log, largeTest-part2.log, largeTest-part3.log
+        // NOT largeTest-part1-part1.log etc.
+        $this->assertFileExists($logDir.'/largeTest-part1.log');
+        $this->assertFileExists($logDir.'/largeTest-part2.log');
+        $this->assertFileExists($logDir.'/largeTest-part3.log');
+        $this->assertFileDoesNotExist($logDir.'/largeTest-part1-part1.log');
+        $this->assertFileDoesNotExist($logDir.'/largeTest-part1-part2.log');
 
         $this->cleanupLogFiles();
     }


### PR DESCRIPTION
## Summary

Ports all major fixes from the 2.x branch (#15) to the 1.x branch, adapting for the 1.x controller/serializer architecture.

### Bugs fixed

- **Compounding split filenames** — `SplitLargeLogfilesCommand` was not stripping existing `-partN` suffixes before splitting, causing filenames like `flarum-2026-01-25-part3-part6-part9-...-part100.log` after repeated daily runs
- **Daily re-splitting** — after splitting, the original file was renamed as the last part instead of being deleted, so it kept exceeding the size limit and being re-split every day
- **`Finder` singleton** — `ListLogfilesController` injected `Finder` from the container (a stateful singleton), causing repeated list calls to fail; replaced with `new Finder()` per request
- **`resolve(Finder::class)` in `LogFile::find()`** — same singleton bug; replaced with direct `realpath()`-based lookup
- **`CleanupLogfilesCommand` sentinel value** — `getPurgeDays()` returned `-1` for negative input, but the disabled check was `<= 0`, so negative values accidentally ran cleanup; now returns `0`
- **`Finder::size()` comparator** — missing space between `>` and the size value (e.g. `>1048576` → `> 1048576`)

### New features

- **Subdirectory log file support** (closes #9) — files in subdirectories of the log directory are now listed, viewable, downloadable, and deletable. Resource IDs are base64url-encoded relative paths (e.g. `subdir/flarum.log` → `c3ViZGlyL2ZsYXJ1bS5sb2c`) so they are URL-safe without ambiguity
- **`relativePath` attribute** — serializer now exposes `relativePath` alongside `fileName`; frontend uses it for display and all API calls

### Permission rename

- `readLogfiles` → `manageLogfiles` (matches the 2.x branch)

## Test plan

- [ ] All 31 integration tests pass (PHPUnit 9)
- [ ] PHPStan reports no errors
- [ ] New subdirectory tests: list, view, download, delete
- [ ] New resplit regression test: confirms splitting an already-split file produces `largeTest-part1.log` / `largeTest-part2.log` / `largeTest-part3.log`, not `largeTest-part1-part1.log` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)